### PR TITLE
Fix usage of multiple spread operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "inferno"
   ],
   "scripts": {
-    "test": "rimraf tests/temp && ts-node tests/index.ts",
-    "debug": "rimraf tests/temp && npm run build && node --inspect-brk --require ts-node/register tests/index.ts",
+    "test": "rimraf tests/temp && rimraf tests/tempES6 && ts-node tests/index.ts",
+    "debug": "rimraf tests/temp && rimraf tests/tempES6 && npm run build && node --inspect-brk --require ts-node/register tests/index.ts",
     "build": "tsc",
     "overwrite-references": "ts-node tests/overwriteReferences.ts",
     "prepublishOnly": "rimraf dist && tsc"

--- a/tests/cases/spreadAttribute7.tsx
+++ b/tests/cases/spreadAttribute7.tsx
@@ -1,0 +1,1 @@
+<div {...props} {...other} {...more} foo="bar" />;

--- a/tests/cases/spreadAttribute7.tsx
+++ b/tests/cases/spreadAttribute7.tsx
@@ -1,1 +1,1 @@
-<div {...props} {...other} {...more} foo="bar" />;
+<div {...props} {...other} foo="bar" foo2="bar2" {...more} foo3="bar3" />;

--- a/tests/references/spreadAttribute5.jsx
+++ b/tests/references/spreadAttribute5.jsx
@@ -9,4 +9,4 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
 import * as inferno from "inferno";
 var normalizeProps = inferno.normalizeProps;
 var createVNode = inferno.createVNode;
-normalizeProps(createVNode(1, "div", "test", null, 1, __assign({}, props, { "foo": "bar" })));
+normalizeProps(createVNode(1, "div", "test", null, 1, __assign({}, { "foo": "bar" }, props)));

--- a/tests/references/spreadAttribute7.jsx
+++ b/tests/references/spreadAttribute7.jsx
@@ -1,0 +1,12 @@
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+import * as inferno from "inferno";
+var normalizeProps = inferno.normalizeProps;
+var createVNode = inferno.createVNode;
+normalizeProps(createVNode(1, "div", null, null, 1, __assign({}, props, other, more, { "foo": "bar" })));

--- a/tests/references/spreadAttribute7.jsx
+++ b/tests/references/spreadAttribute7.jsx
@@ -9,4 +9,4 @@ var __assign = (this && this.__assign) || Object.assign || function(t) {
 import * as inferno from "inferno";
 var normalizeProps = inferno.normalizeProps;
 var createVNode = inferno.createVNode;
-normalizeProps(createVNode(1, "div", null, null, 1, __assign({}, props, other, more, { "foo": "bar" })));
+normalizeProps(createVNode(1, "div", null, null, 1, __assign({}, props, other, { "foo": "bar", "foo2": "bar2" }, more, { "foo3": "bar3" })));

--- a/tests/referencesES6/spreadAttribute5.jsx
+++ b/tests/referencesES6/spreadAttribute5.jsx
@@ -1,2 +1,2 @@
 import { createVNode, normalizeProps } from "inferno";
-normalizeProps(createVNode(1, "div", "test", null, 1, Object.assign({}, props, { "foo": "bar" })));
+normalizeProps(createVNode(1, "div", "test", null, 1, Object.assign({}, { "foo": "bar" }, props)));

--- a/tests/referencesES6/spreadAttribute7.jsx
+++ b/tests/referencesES6/spreadAttribute7.jsx
@@ -1,2 +1,2 @@
 import { createVNode, normalizeProps } from "inferno";
-normalizeProps(createVNode(1, "div", null, null, 1, Object.assign({}, props, other, more, { "foo": "bar" })));
+normalizeProps(createVNode(1, "div", null, null, 1, Object.assign({}, props, other, { "foo": "bar", "foo2": "bar2" }, more, { "foo3": "bar3" })));

--- a/tests/referencesES6/spreadAttribute7.jsx
+++ b/tests/referencesES6/spreadAttribute7.jsx
@@ -1,0 +1,2 @@
+import { createVNode, normalizeProps } from "inferno";
+normalizeProps(createVNode(1, "div", null, null, 1, Object.assign({}, props, other, more, { "foo": "bar" })));


### PR DESCRIPTION
Based on this issue: https://github.com/deamme/ts-transform-inferno/issues/20
Previously only the last spread operator was taken into account and the ordering of the props was changed. Now this should be in line with babel-plugin-inferno, e.g. transforms all spread operators and does not change the order of the props given. 